### PR TITLE
Pass resolv_timeout to Socket.tcp

### DIFF
--- a/lib/bunny/cruby/socket.rb
+++ b/lib/bunny/cruby/socket.rb
@@ -27,7 +27,7 @@ module Bunny
 
     def self.open(host, port, options = {})
       socket = ::Socket.tcp(host, port, nil, nil,
-                            connect_timeout: options[:connect_timeout])
+                            connect_timeout: options[:connect_timeout], resolv_timeout: options[:connect_timeout])
       if ::Socket.constants.include?('TCP_NODELAY') || ::Socket.constants.include?(:TCP_NODELAY)
         socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
       end


### PR DESCRIPTION
Pass a resolv timeout option to Socket.tcp, using the same value
as connect timeout.

Without this argument, Socket.tcp may hang indefinitely on dns
resolution.

The resolve_timeout option will only have affect if the glibc
function `getaddrinfo_a' is present.
