### PR TITLE
PLT-830 Replace DNS Library

### DIFF
--- a/bunny.gemspec
+++ b/bunny.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   # Dependencies
   s.add_runtime_dependency 'amq-protocol', '~> 2.3', '>= 2.3.1'
   s.add_runtime_dependency 'sorted_set', '~> 1', '>= 1.0.2'
+  s.add_runtime_dependency 'resolv-replace'
 
   # Files.
   s.extra_rdoc_files = ["README.md"]

--- a/bunny.gemspec
+++ b/bunny.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   # Dependencies
   s.add_runtime_dependency 'amq-protocol', '~> 2.3', '>= 2.3.1'
   s.add_runtime_dependency 'sorted_set', '~> 1', '>= 1.0.2'
-  s.add_runtime_dependency 'resolv-replace'
+  s.add_runtime_dependency 'resolv-replace', '~> 0.1.1'
 
   # Files.
   s.extra_rdoc_files = ["README.md"]

--- a/lib/bunny/cruby/socket.rb
+++ b/lib/bunny/cruby/socket.rb
@@ -1,4 +1,5 @@
 require "socket"
+require "resolv-replace"
 
 module Bunny
   # TCP socket extension that uses TCP_NODELAY and supports reading
@@ -26,8 +27,7 @@ module Bunny
                                     end
 
     def self.open(host, port, options = {})
-      socket = ::Socket.tcp(host, port, nil, nil,
-                            connect_timeout: options[:connect_timeout], resolv_timeout: options[:connect_timeout])
+      socket = TCPSocket.new(host, port)
       if ::Socket.constants.include?('TCP_NODELAY') || ::Socket.constants.include?(:TCP_NODELAY)
         socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
       end

--- a/lib/bunny/version.rb
+++ b/lib/bunny/version.rb
@@ -2,5 +2,5 @@
 
 module Bunny
   # @return [String] Version of the library
-  VERSION = "2.23.0.pre"
+  VERSION = "2.3.0.pre"
 end

--- a/lib/bunny/version.rb
+++ b/lib/bunny/version.rb
@@ -2,5 +2,5 @@
 
 module Bunny
   # @return [String] Version of the library
-  VERSION = "2.3.0.pre"
+  VERSION = "2.3.0"
 end


### PR DESCRIPTION
Add resolv-replace gem, this monkey patches TCPSocket with a ruby based DNS lookup

Swap out bunny's usage of `Socket.tcp` with TCPSocket in order to use the monkey patched class.